### PR TITLE
Update AMOptionPopUpButtonCell.m

### DIFF
--- a/AMOptionMenu/AMOptionPopUpButton.m
+++ b/AMOptionMenu/AMOptionPopUpButton.m
@@ -129,5 +129,9 @@
 	[super setTitle:title];
 }
 
+-(void)dealloc
+{
+  [self unbind:@"title"];
+}
 
 @end

--- a/AMOptionMenu/AMOptionPopUpButtonCell.m
+++ b/AMOptionMenu/AMOptionPopUpButtonCell.m
@@ -101,10 +101,12 @@
 	[[NSNotificationCenter defaultCenter] removeObserver:self name:kAMOptionMenuContentDidChange object:_optionMenuController];
 
 	_optionMenuController = controller;
-
-	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(optionsChanged:) name:kAMOptionMenuContentDidChange object:_optionMenuController];
-
+	
 	[self updateMenu];
+
+	if (controller ==nil) return;
+	
+	[[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(optionsChanged:) name:kAMOptionMenuContentDidChange object:_optionMenuController];
 }
 
 


### PR DESCRIPTION
This change allowes to set the options controller to nil and allows to re-use, re-create, etc the popup menu without leaking memory via nsnotification center (in fact, when the observation leaks the app crashes).
